### PR TITLE
feat(settings): add DisableUserStatusCheck (default on) and honor it …

### DIFF
--- a/integrations/app/src/main/java/app/revanced/bilibili/account/Accounts.kt
+++ b/integrations/app/src/main/java/app/revanced/bilibili/account/Accounts.kt
@@ -172,6 +172,17 @@ object Accounts {
 
     @JvmStatic
     private fun checkUserStatus() = runCatching {
+        // 若用户在设置中关闭了资格/黑名单校验，则直接跳过并清理可能残留的封禁状态
+        if (Settings.DisableUserStatusCheck()) {
+            val mid = Accounts.mid
+            if (mid > 0) {
+                val blockedKey = "user_blocked_" + mid
+                if (cachePrefs.getBoolean(blockedKey, false))
+                    cachePrefs.edit { putBoolean(blockedKey, false) }
+            }
+            userBlocked = false
+            return@runCatching
+        }
         val mid = Accounts.mid
         if (mid <= 0) return@runCatching
         val checkInterval = TimeUnit.HOURS.toMillis(1)

--- a/integrations/app/src/main/java/app/revanced/bilibili/settings/Settings.kt
+++ b/integrations/app/src/main/java/app/revanced/bilibili/settings/Settings.kt
@@ -275,6 +275,8 @@ object Settings {
             clearSplashConfigCache()
         }
     })
+    // 当开启时，跳过服务端黑名单/资格校验并强制视为未封禁（默认开启）
+    @JvmField val DisableUserStatusCheck = BooleanSetting(key = "disable_user_status_check", defValue = true)
     @JvmField val DisallowCollectPrivacyInfo = BooleanSetting(key = "disallow_collect_privacy_info", needReboot = true)
     @JvmField val DisableWebViewNonOfficialAlert = BooleanSetting(key = "disable_non_official_alert")
     // endregion


### PR DESCRIPTION
…in Accounts.checkUserStatus()\n\n- New setting: disable_user_status_check (defValue=true)\n- Skip server blacklist/eligibility check when enabled\n- Clear local blocked flag and reset userBlocked=false on skip