### PR TITLE
ci(patch): unify patch workflow; auto Release asset; script extraction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,63 +1,47 @@
-## BiliRoamingX · Copilot 指南（面向 AI 代理）
+## BiliRoamingX · Copilot 指南（面向 AI 代理，简明版）
 
-本仓库是基于 ReVanced 的 B 站 Android 增强方案，包含补丁包（patch-bundle JAR）与集成 APK（integrations.apk），以及原生 Hook（Dobby）。请遵循下列要点高效协作。
+本仓库基于 ReVanced，为哔哩哔哩注入增强功能；产物包括补丁包 JAR（patch-bundle）与集成 APK（integrations.apk），并含原生 Hook（Dobby）。
 
-### 架构速览
-- 模块划分
-  - patches（Kotlin/JVM）：补丁定义与生成。输出补丁包 JAR 与 patches.json。
-  - integrations/app（Android App）：运行时集成代码与资源、原生库（libbiliroamingx.so）。补丁将注入对该 APK 中代理/委托方法的调用。
-  - integrations/dummy：仅编译期依赖的桩与三方 API（如 gRPC、AndroidX），供其他模块 compileOnly 参照。
-  - integrations/extend：供 integrations/app 使用的库模块。
-  - integrations/ksp：KSP 符号处理器，构建时生成所需代码（勿直接修改生成物）。
-  - build-logic：统一 Android/NDK/CMake/JVM 版本与 buildType（含 dev）。
-- 关键数据流
-  1) ReVanced 加载 patches.jar 中的 @Patch 声明并修改宿主（B 站）字节码；
-  2) 被修改的方法调用 integrations.apk 内的代理方法（如 Lapp/revanced/bilibili/patches/...）；
-  3) 原生层通过 Dobby 进行 Hook；资源补丁通过 resources 合并。
+### 架构与数据流
+- 模块：
+  - patches（Kotlin/JVM 11）：定义补丁与生成补丁包；输出 patches.jar 与 patches.json。
+  - integrations/app（Android App）：运行时代理/资源与原生库 `libbiliroamingx.so`。
+  - integrations/dummy（编译期桩）、integrations/extend（库）、integrations/ksp（KSP 处理器）、build-logic（统一版本与构建配置）。
+- 流程：ReVanced 读取 patches.jar 中的 `@Patch` → 修改宿主字节码 → 调用 `integrations.apk` 中代理类（如 `Lapp/revanced/bilibili/...`）→ 原生通过 Dobby Hook；资源补丁通过资源合并。
 
-### 构建与产物
-- 快速开发构建：`./gradlew distDev`（禁用 full R8，较快）。
-- 发布构建：`./gradlew dist`。
-- 产物归并到顶层 `build/`：
-  - APK：`BiliRoamingX-<module>-<version>.apk`（来自 `:integrations:app`）。
-  - JAR：`BiliRoamingX-patches-<version>.jar`（含 classes.dex）。
-  - patches.json：补丁元数据清单。
-  - 注意：根任务会把 APK 的 `lib/**` 拷贝进 JAR 的 `bilibili/lib/**`（见根 `build.gradle.kts` 的 dist 任务）。
-- 前置条件：为 `:patches:buildDexJar` 提供 d8（Android SDK）。需设置 ANDROID_HOME 或在 `local.properties` 写入 `sdk.dir`。
+### 构建与产物（根目录执行）
+- 开发构建：`./gradlew distDev`（minify 且关闭 full R8，较快）。发布构建：`./gradlew dist`。
+- 输出至 `build/`：`BiliRoamingX-integrations-<ver>.apk`、`BiliRoamingX-patches-<ver>.jar`（含 classes.dex）与 `patches.json`、`mapping.txt`。
+- dist 会把 APK 的 `lib/**` 拷贝到 JAR 的 `bilibili/lib/**`（见根 `build.gradle.kts` 的 dist 任务）。
+- 前置：提供 d8（设置 ANDROID_HOME 或 `local.properties` 的 `sdk.dir`）；clone 时使用 `--recurse-submodules` 以包含 `integrations/libs/Dobby`。
 
-### 版本与构建约束
-- 统一参数见 `build-logic/src/main/kotlin/Versions.kt`：compile/target SDK 35、minSdk 24、NDK 26.3、CMake 3.22.1、JVM 17（patches 模块使用 11）。
-- `integrations/app` 的 `versionName` 来自 `gradle.properties` 的 `version`，versionCode 由主/次/修订按 m*1_000_000 + s*1_000 + f 计算。
-- CMake 在 `integrations/app/src/main/jni/CMakeLists.txt`，链接 `integrations/libs/Dobby` 子模块（clone 时务必 `--recurse-submodules`）。
+### 版本/构建约束与差异
+- 统一参数见 `build-logic/src/main/kotlin/Versions.kt`：compile/target SDK 35、minSdk 24、NDK 26.3、CMake 3.22.1、JVM 17（仅 patches 使用 JVM 11）。
+- `integrations/app` versionName 取自根 `gradle.properties` 的 `version`；versionCode = m*1_000_000 + s*1_000 + f。
+- CMake：`integrations/app/src/main/jni/CMakeLists.txt` 链接 Dobby 子模块。
 
-### 补丁开发约定（patches 模块）
-- 典型形态：对象继承 `BytecodePatch` 或 `ResourcePatch`，使用 `@Patch` 声明 `name/description/compatiblePackages/use/dependencies` 等。
-- 定位目标：`.../fingerprints` 内定义 Fingerprint；`execute(BytecodeContext)` 中通过扩展方法进行插桩（见 `patches/.../utils/Extenstions.kt`）。
-- 注入调用到 integrations：以 Smali 形式插入调用，如 MainActivityPatch 将调用 `Lapp/revanced/bilibili/patches/main/MainActivityDelegate;->onCreate(...)V`。
-- 资源补丁示例：`all/misc/packagename/ChangePackageNamePatch.kt`、`all/misc/debugging/EnableAndroidDebuggingPatch.kt`（默认 `use = false`）。
+### 开发补丁（patches 模块）
+- 新增补丁：继承 `BytecodePatch` 或 `ResourcePatch` 并用 `@Patch` 声明 `name/compatiblePackages/use/dependencies` 等。
+- 目标定位：在 `.../fingerprints` 定义 Fingerprint；在 `execute(BytecodeContext)` 内用扩展方法做插桩。
+- 注入调用：以 Smali 形式调用 integrations 代理，例如 `MainActivityPatch` 调用
+  `Lapp/revanced/bilibili/patches/main/MainActivityDelegate;->onCreate(...)V`。
+- 代表路径（示例）：`.../misc/integrations/patch/MainActivityPatch.kt`、`.../misc/config/patch/ConfigPatch.kt`、`.../misc/json/patch/PegasusPatch.kt`。
 
-### 集成侧约定（integrations/app 模块）
-- 被补丁调用的代理/委托实现位于 `integrations/app/src/main/java/app/revanced/bilibili/**`（例如 `patches/json/PegasusPatch.java`、`patches/main/MainActivityDelegate`）。保持方法签名与补丁注入一致。
-- 构建特性：
-  - buildTypes 包含 `dev` 与 `release`，两者均 minify；`distDev` 下强制关闭 full R8（见 R8Task 设置）。
-  - 打包排除 `libc++_shared.so` 与部分 META-INF/kotlin 资源，避免与宿主重复。
-  - 依赖：HiddenApiBypass、kotlinx-serialization、AndroidX DocumentFile（排除 annotation）。
+### 集成侧约定（integrations/app）
+- 代理实现位于 `integrations/app/src/main/java/app/revanced/bilibili/**`（如 `patches/json/PegasusPatch.java`、`patches/main/MainActivityDelegate`）。务必与补丁注入的方法签名完全一致。
+- buildTypes：`dev` 与 `release` 均 minify；`distDev` 关闭 full R8。打包排除 `libc++_shared.so` 与部分 META-INF/kotlin 资源。
+- 依赖：HiddenApiBypass、kotlinx-serialization、AndroidX DocumentFile（排除 annotation）。KSP 代码为生成物，勿直接修改（默认在各模块 `build/generated/...`）。
 
-### 常见问题与陷阱
-- 未配置 Android SDK 导致 d8 不可用：`Android sdk not found.` → 设置 ANDROID_HOME 或 `local.properties`。
-- 未递归拉取子模块导致 Dobby 缺失：构建原生失败 → `git clone --recurse-submodules ...`。
-- 产物重命名/路径不符会导致根 dist 任务无法归并或 JAR 未包含 `bilibili/lib/**`。
+### 外部打包与快速验证
+- 用 revanced-cli 合并：`java -jar revanced-cli.jar patch --merge integrations.apk --patch-bundle patches.jar --signing-levels 1,2,3 bilibili.apk`。
+- 快速验证：微调某个代理/补丁 → 运行 `distDev` → 检查 `build/` 产物存在并体积合理 → 使用上面命令对目标 bilibili.apk 试合并。
 
-### 外部打包（供使用者）
-- 参考 README：使用自定义 revanced-cli 合并补丁与集成 APK。
-  `java -jar revanced-cli.jar patch --merge integrations.apk --patch-bundle patches.jar --signing-levels 1,2,3 bilibili.apk`
+### 常见陷阱（优先排查）
+- 未配置 Android SDK/d8 → `Android sdk not found.`；未拉取子模块 → Dobby 缺失导致原生构建失败。
+- 代理方法签名不匹配 → 运行时崩溃或 NPE；产物重命名/路径变更 → dist 无法归并或 JAR 丢失 `bilibili/lib/**`。
 
-### 快速定位与参考
-- 根构建与归并逻辑：`build.gradle.kts`（dist/distDev）。
-- 补丁生成：`patches/build.gradle.kts`（buildDexJar、generatePatchesFiles）与 `patches/src/main/kotlin/app/revanced/generator/*`。
-- 代表性补丁：
-  - `.../misc/integrations/patch/MainActivityPatch.kt`（主界面代理），
-  - `.../misc/config/patch/ConfigPatch.kt`（配置代理），
-  - `.../misc/json/patch/PegasusPatch.kt`、`.../misc/copy/patch/CopyEnhancePatch.kt`。
+### 关键参考文件/目录
+- 根构建与归并：`build.gradle.kts`；补丁生成：`patches/build.gradle.kts` 与 `patches/src/main/kotlin/app/revanced/generator/*`。
+- Dobby：`integrations/libs/Dobby/**`；原生 CMake：`integrations/app/src/main/jni/CMakeLists.txt`。
 
-如果上述任何部分不清晰（尤其是补丁与集成方法签名匹配、dist 归并细节、KSP 产物位置），请指出我来补充或修正。
+如需补充（例如具体 KSP 产物路径、更多代表性补丁位置、调试/日志最佳实践），请告诉我以便完善本指南。

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,87 @@
+name: Patch Bilibili APK
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      apk_url:
+        description: Bilibili APK download URL override
+        required: false
+        default: https://dl.hdslb.com/mobile/latest/android64/iBiliPlayer-bili.apk
+  release:
+    types: [published]
+
+jobs:
+  patch:
+    name: Build patched APK and publish release asset
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download CI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Download all artifacts from the triggering workflow run
+          # The CI uploads 'build' dir under name 'BiliRoamingX-${{ env.VERSION }}'
+          # Here we download all and locate the needed files.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || '' }}
+          path: ci-artifacts
+
+      - name: Prepare script
+        run: |
+          chmod +x scripts/patch_bilibili.sh
+
+      - name: Set up JDK 17 (match CI)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Run patch script
+        env:
+          APK_URL: ${{ github.event.inputs.apk_url || '' }}
+          ARTIFACTS_DIR: ci-artifacts
+          BUILD_DIR: build
+        run: |
+          scripts/patch_bilibili.sh
+
+      - name: Resolve output
+        id: resolve
+        run: |
+          set -euo pipefail
+          test -f build/patch-result.txt
+          APK=$(cat build/patch-result.txt)
+          echo "apk=$APK" >> $GITHUB_OUTPUT
+          echo "Resolved APK=$APK"
+
+      - name: Upload patched APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: bilibili-patched
+          path: |
+            build/${{ steps.resolve.outputs.apk }}
+            build/bilibili-patch-full.log
+            build/bilibili-patch-min.log
+            build/bilibili-patched.sha256
+
+      - name: Create/Update Release and upload asset
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name || 'latest' }}
+          name: Automated patched build
+          files: build/${{ steps.resolve.outputs.apk }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/patch_bilibili.sh
+++ b/scripts/patch_bilibili.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# patch_bilibili.sh
+# Downloads bilibili.apk and revanced-cli.jar (if missing), copies integrations/patch-bundle from CI artifacts dir,
+# attempts full patch, and falls back to a minimal reliable set. Writes output APK path to patch-result.txt.
+
+APK_URL=${APK_URL:-"https://dl.hdslb.com/mobile/latest/android64/iBiliPlayer-bili.apk"}
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"ci-artifacts"}
+BUILD_DIR=${BUILD_DIR:-"build"}
+
+mkdir -p "$BUILD_DIR"
+
+echo "[patch] Using APK_URL=$APK_URL"
+echo "[patch] Using ARTIFACTS_DIR=$ARTIFACTS_DIR"
+
+# Locate artifacts
+shopt -s globstar nullglob
+INTEGRATIONS=$(ls -1 "$ARTIFACTS_DIR"/**/BiliRoamingX-integrations-*.apk | head -n1 || true)
+PATCH_BUNDLE=$(ls -1 "$ARTIFACTS_DIR"/**/BiliRoamingX-patches-*.jar | head -n1 || true)
+
+if [[ -z "$INTEGRATIONS" || -z "$PATCH_BUNDLE" ]]; then
+  echo "::error::Cannot find integrations apk or patches jar in artifacts" >&2
+  exit 1
+fi
+
+cp -v "$INTEGRATIONS" "$BUILD_DIR/"
+cp -v "$PATCH_BUNDLE" "$BUILD_DIR/"
+
+# Download inputs if missing
+if [[ ! -f "$BUILD_DIR/bilibili.apk" ]]; then
+  curl -fL --retry 3 -o "$BUILD_DIR/bilibili.apk" "$APK_URL"
+fi
+if [[ ! -f "$BUILD_DIR/revanced-cli.jar" ]]; then
+  curl -fL --retry 3 -o "$BUILD_DIR/revanced-cli.jar" \
+    https://github.com/zjns/revanced-cli/releases/latest/download/revanced-cli.jar
+fi
+
+pushd "$BUILD_DIR" >/dev/null
+
+INTEGRATIONS_BASENAME=$(basename "$INTEGRATIONS")
+PATCH_BUNDLE_BASENAME=$(basename "$PATCH_BUNDLE")
+
+echo "[patch] Full patch attempt"
+set +e
+JAVA_TOOL_OPTIONS="-Xmx2048m -XX:+UseSerialGC" java -jar revanced-cli.jar patch \
+  --merge "$INTEGRATIONS_BASENAME" \
+  --patch-bundle "$PATCH_BUNDLE_BASENAME" \
+  --signing-levels 1 \
+  -o bilibili-patched-full.apk \
+  bilibili.apk | tee bilibili-patch-full.log
+CODE=$?
+FULL_SUCCESS=0
+if [[ $CODE -eq 0 && -f bilibili-patched-full.apk ]]; then
+  FULL_SUCCESS=1
+fi
+set -e
+
+if [[ $FULL_SUCCESS -ne 1 ]]; then
+  echo "[patch] Full attempt failed; fallback to minimal set"
+  JAVA_TOOL_OPTIONS="-Xmx1024m -XX:+UseSerialGC" java -jar revanced-cli.jar patch \
+    --exclusive \
+    --merge "$INTEGRATIONS_BASENAME" \
+    --patch-bundle "$PATCH_BUNDLE_BASENAME" \
+    --include "Integrations" \
+    --include "BiliRoamingX settings entrance" \
+    --include "Config" \
+    --include "Config integration" \
+    --include "Main activity patch" \
+    --include "Bili library patch" \
+    --include "Json" \
+    --include "OkHttp" \
+    --include "Override certificate pinning" \
+    --include "BLog" \
+    --include "Pegasus hook" \
+    --signing-levels 1 \
+    -o bilibili-patched-min.apk \
+    bilibili.apk | tee bilibili-patch-min.log
+  OUT="bilibili-patched-min.apk"
+else
+  OUT="bilibili-patched-full.apk"
+fi
+
+ls -lh "$OUT"
+sha256sum "$OUT" | tee bilibili-patched.sha256
+echo "$OUT" | tee patch-result.txt
+
+popd >/dev/null
+
+echo "[patch] Done. Output at $BUILD_DIR/$OUT"


### PR DESCRIPTION
This PR unifies patching automation into a single workflow and extracts a reusable script.\n\nKey changes:\n- Add scripts/patch_bilibili.sh (full attempt then minimal fallback)\n- New .github/workflows/patch.yml: triggers on CI success/release/manual, uses JDK 17\n- Always creates/updates a Release and uploads the patched APK\n- Downloads CI artifacts (integrations & patch-bundle) for patching\n- Updates Copilot guide for concise context\n\nNotes:\n- Tag naming currently defaults to github.ref_name or 'latest'. We can wire the CI-derived VERSION if preferred.\n- Minimal patch set mirrors local validated list; can be expanded later.\n